### PR TITLE
feat: gate agents and open each project where it was left

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,9 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bezel"
-version = "0.1.4"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86f4c0160281028c230c247da7be1e873abef3e607798863fbc2a462d1c44e9"
 dependencies = [
  "bezel-agent",
  "bezel-gpui",
@@ -564,7 +566,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-agent"
-version = "0.1.4"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0283098c6791dab1f17e3cbbe1d4560debcc442ede8699d8d7324814f09141a"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -573,7 +577,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-editor"
-version = "0.1.4"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "466d21aeb314936e245a2b656fa3c3a2640728d846b6b57e53ff8e47d751fee1"
 dependencies = [
  "bezel-gpui",
  "bezel-markdown",
@@ -584,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a008851c64f7cc52dd017e93017fa920e1f1d64d01283bc99cc13a96a5c5221b"
+checksum = "57766bae2078b67a3385b838851e3255ee158e2427667ad775e98b7ea38b2de5"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -654,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-apple"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ff465a9fe2ee962f372f2a3ef32b67898c59ee0cd6231f561a37dd99fbd9f"
+checksum = "b25f9a349efada0f586470cf20caa3a178af6ef1f49c558a206a653f1e645fce"
 dependencies = [
  "anyhow",
  "bezel-gpui",
@@ -678,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-linux"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6533293f48e283018afcbe67ec82fc5932d99bf6c0c8e76b3c76329b2901bb65"
+checksum = "083be2d7d384c73921b6d874c04abba5922d48e1a41d0767b5f22137f31b048b"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -707,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-macos"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c523333ea0457e286501fa0624fe83dd966443e01de56e8c8b5da495ce9def"
+checksum = "23bb0dfcfb9c64471b70070f7bd3eef0594ddddc324fdef3132b46e16aa71ffb"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -754,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-macros"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c1cc4418936a395442070a3e2a6f8a5551f3e3c660b60defd39ce83e7070f8"
+checksum = "3b9e51dfcd3c65b01b99c00d06702051bbade5e9e0e43f7112bce5cf2af4b59b"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -766,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-platform"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7938490f30e99b03934cad8acc3cb366ad9a6ba05679729f54212059b292"
+checksum = "f9f601ff3fcc53c73b1a46ad2f672e2c4de9cd16edbd099724f5978fd5569390"
 dependencies = [
  "bezel-gpui",
  "bezel-gpui-linux",
@@ -781,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-shared-string"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245e78af981785d84b61ee75403bc41f69fe68184c5085f11c409c6b9ecd246c"
+checksum = "3a685835ce331d98d5cd32fca8a1150dd7cceaf0d8e6ee489852841fe75ba8a5"
 dependencies = [
  "schemars",
  "serde",
@@ -792,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-util"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "042d3430d654881323d718cfaf186e09bc14072158067ebda31d543a6dea8786"
+checksum = "27cb206ddd0e5f8d4ced6c5ed7eeeecd28e65f5e7df28f659b96d2ab54117ddd"
 dependencies = [
  "anyhow",
  "log",
@@ -803,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-web"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec1494972d9c59bf1692fbe85e1cfd05cdbe3b64e4d56346f0a3753a342b6f7"
+checksum = "97750b3a8cf2fb9d3359b62da4a95e7e71fbf88b5d62bf285b8c9b2d5115426c"
 dependencies = [
  "anyhow",
  "bezel-gpui",
@@ -827,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-wgpu"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478e42f908577b12ee5eba4fec7f72e9098e37395c2c72b1d4ae39334f84de5c"
+checksum = "36a280d9f8aa8195db946ad44ba5f4b1580605d2c52601c58954775d58a4124b"
 dependencies = [
  "anyhow",
  "bezel-gpui",
@@ -853,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-gpui-windows"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8147cd73aa620a249c42320b9d4baf8a3661653171b2f2ca4cc1899807a59467"
+checksum = "406df44e8d6414d027fbf69a22b4285934b8821f5bdf25a2d9f14adb480c6548"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -882,7 +888,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-markdown"
-version = "0.1.4"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f8095a15fc9598897c7c15fdb61853299a74b65f666a66ea06093ea2234d28"
 dependencies = [
  "bezel-gpui",
  "bezel-theme",
@@ -891,7 +899,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-motion"
-version = "0.1.4"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865637abaeb27bebb8e959352586be1219b1fbeea33a996cd2c598421fc40cde"
 dependencies = [
  "bezel-gpui",
  "web-time",
@@ -899,7 +909,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-syntax"
-version = "0.1.4"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8037fd449fb7e3d184dd1b7e6dc8b89fb092e364abaa09ee82f0404ad25f672"
 dependencies = [
  "bezel-theme",
  "tree-sitter",
@@ -916,7 +928,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-theme"
-version = "0.1.4"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d212a8c3270a0bfc4677afcc380ac84ba7c44ac79bcd917660f6bfd9d2155f5"
 dependencies = [
  "bezel-gpui",
  "objc",
@@ -926,7 +940,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-ui"
-version = "0.1.4"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a184f56ecd20c13ae1cf686411b19c155df715d00eee26c3cb5e0cb73f0520d"
 dependencies = [
  "bezel-gpui",
  "bezel-motion",
@@ -938,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-collections"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4be277cf141aed9e75272238a627bfc55b367c31f9ecc0cca2ceb04a2781bea"
+checksum = "5dc117f26f2a469d38c7602e0b67d419298412fef79ac9a17d28e995bdb56715"
 dependencies = [
  "bezel-gpui-util",
  "indexmap",
@@ -949,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-derive-refineable"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0e3e281fac3dd8b65c59d0d0ad0929940d7ea0811b006d7d8c4fd1e9425b5a"
+checksum = "2239c81389497320e4d579522b1422d6cdcdc9790ccc2e3524a8f7fb9c4b4fca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -960,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-http-client"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c85722062e1ae0d9dd522fb6547275d26d0941a05a6d60a65d4de2709004d3"
+checksum = "f2daf34adec482ccd3ee835998e3292c6ee554706d1096d3e3732e6d629e4df6"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -981,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-http-client-tls"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90220b7edc8d69053f8ae0f2ef1198d19950a0ba0ececa9121430911da8445dd"
+checksum = "c0062934d7c8f678cf3340cc39bb865f235bc4de54eb4f27b58f05dd7c79de89"
 dependencies = [
  "log",
  "rustls",
@@ -993,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-media"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b808ec1973a7c751b1e6e0960db4882d3a6d8b0d86009a4a57cac13fa89ed2eb"
+checksum = "d5b188238a8087253a210d61c51c11eabd894038f2c4a0c0c8456666de5c89e9"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -1008,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-perf"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a15da41b7b4d3d5a561c7c5f0ba5ddb903fa36507df4d5cf3c4da04d6b3c504"
+checksum = "6ea5c03b94eef38d3e62046a94c9d80d182ec4a6b0304b261541af76b7d2e55a"
 dependencies = [
  "bezel-zed-collections",
  "serde",
@@ -1019,18 +1035,18 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-refineable"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b66f5f993d7e01bbe4da4c5225f0b845ab1291d57db0c6f6535f64a210a24e"
+checksum = "70e8f4b7b6608b17f364d11ebfc91e62b772d5e1d41c576801592345d92aef0c"
 dependencies = [
  "bezel-zed-derive-refineable",
 ]
 
 [[package]]
 name = "bezel-zed-reqwest-client"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "694369eeaedc0c38b8b3efcd565c348bc96734b10d0423a430689df195904f09"
+checksum = "6398b85c31aab6d45da5a0c488c1f7d665ee2b63368f661cd793e701c95b61d7"
 dependencies = [
  "anyhow",
  "bezel-gpui-util",
@@ -1046,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-scheduler"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440497d2726120bec04c10bf5dd7bfd303a69837db828070e369d6aa92cdcaea"
+checksum = "ce3d78351e6c811e1daaadb5a0b7a0c75d5a141ca33249b1c7d577fe46fbbd56"
 dependencies = [
  "async-task",
  "backtrace",
@@ -1062,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-sum-tree"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820330b74a1d51228dafbb90565c92b263b13a70f77f0306329ac6688b3d17b4"
+checksum = "e4a727372bb43f3b11f3a9f27cd66b006d2ddb5a6a7c8ef538b0beaa0eabdb2b"
 dependencies = [
  "bezel-zed-ztracing",
  "heapless",
@@ -1075,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-util-macros"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5464574477b54505ca413876d6c306a3e30364c25ad34de6d3145611b27adf1"
+checksum = "c3678b8627ac4aa3c242e0a44fb06a43d92c565791b592e980d19e1300da5509"
 dependencies = [
  "bezel-zed-perf",
  "quote",
@@ -1086,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-zlog"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86be3224a86b294d47afafbffde1c82d9aca4034a882e5cc188a66032b8583df"
+checksum = "2c4300f80d6716239b8693be09b56904e0b84d24245ad2bc2858de7f96708561"
 dependencies = [
  "anyhow",
  "bezel-zed-collections",
@@ -1098,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-ztracing"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97e00c94718f19851b1239f6718bd658e3607c902fab145c42464e175711671"
+checksum = "9420a900188dcf33b27dac8b867559772a55bdb6866b464e19e004c6311a5ef7"
 dependencies = [
  "bezel-zed-zlog",
  "bezel-zed-ztracing-macro",
@@ -1110,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "bezel-zed-ztracing-macro"
-version = "0.3.8+zed.82aeef"
+version = "0.3.9+zed.82aeef"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0379a6be35ed736b356a28a1bbfeadbb574b6b1f10e40e68ce4f1f4f83304079"
+checksum = "ab91658b3e92b48259d85d1133cbf3fddf455f3d72e9fd64b6e47b3ab01a3f87"
 
 [[package]]
 name = "bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ path = "bin/main.rs"
 # bezel — the component library the GUI is built on. Published as `bezel-*`;
 # the keys here are what the source imports. `platform` carries gpui_platform,
 # which opens the window: gpui core knows no platform of its own.
-bezel = { version = "0.1.4", features = ["platform"] }
-editor = { version = "0.1.4", package = "bezel-editor" }
-markdown = { version = "0.1.4", package = "bezel-markdown" }
-syntax = { version = "0.1.4", package = "bezel-syntax" }
+bezel = { version = "0.1.5", features = ["platform"] }
+editor = { version = "0.1.5", package = "bezel-editor" }
+markdown = { version = "0.1.5", package = "bezel-markdown" }
+syntax = { version = "0.1.5", package = "bezel-syntax" }
 
 # cacp — our ACP implementation. A sibling checkout while both move together.
 cacp = { path = "../cacp/crates/cacp", default-features = false, features = [
@@ -50,16 +50,3 @@ toml_edit = "0.22"
 # Downloads the registry's agent icons. The same client cacp-agents fetches
 # the catalog with, so this adds no second HTTP stack.
 ureq = "3"
-
-# bezel is being fixed in a worktree beside this checkout. Every bezel-* crate
-# in the graph has to come from there together: two copies of the token system
-# is a second type universe, and the window paints shapes but no text.
-[patch.crates-io]
-bezel = { path = "../bezel/crates/bezel" }
-bezel-agent = { path = "../bezel/crates/agent" }
-bezel-editor = { path = "../bezel/crates/editor" }
-bezel-markdown = { path = "../bezel/crates/markdown" }
-bezel-motion = { path = "../bezel/crates/motion" }
-bezel-syntax = { path = "../bezel/crates/syntax" }
-bezel-theme = { path = "../bezel/crates/theme" }
-bezel-ui = { path = "../bezel/crates/ui" }

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -27,11 +27,9 @@ fn main() -> Result<()> {
             if let Err(err) = ui::register_fonts(cx) {
                 eprintln!("font registration failed: {err:?}");
             }
-            // Before the first palette is installed.
-            theme::set_palette(root::palette, cx);
             appearance::init(state.appearance, cx);
             // Before the window is opened: it reads its background appearance
-            // on the way up, and frost is what decides that.
+            // on the way up, and vibrancy is what decides that.
             workspace::apply_transparency(state.reduce_transparency, cx);
             workspace::apply_tint(Tint::new(state.hue, state.chroma), cx);
             input::set_caret_blink(state.cursor_blink, cx);

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -27,6 +27,8 @@ fn main() -> Result<()> {
             if let Err(err) = ui::register_fonts(cx) {
                 eprintln!("font registration failed: {err:?}");
             }
+            // Before the first palette is installed.
+            theme::set_palette(root::palette, cx);
             appearance::init(state.appearance, cx);
             // Before the window is opened: it reads its background appearance
             // on the way up, and frost is what decides that.

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -34,6 +34,7 @@ fn main() -> Result<()> {
             // on the way up, and frost is what decides that.
             workspace::apply_transparency(state.reduce_transparency, cx);
             workspace::apply_tint(Tint::new(state.hue, state.chroma), cx);
+            input::set_caret_blink(state.cursor_blink, cx);
             theme::set_base_text_size(state.text_size, cx);
             markdown::set_highlighter(
                 cx,

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -91,7 +91,7 @@ fn fetch(dir: &Path, id: &str, url: &str) -> Option<String> {
     if let Some(path) = cached(dir, id) {
         return Some(path);
     }
-    let path = dir.join(format!("{id}.svg"));
+    let path = cacp_agents::contained(dir, &format!("{id}.svg")).ok()?;
     let body = ureq::get(url).call().ok()?.body_mut().read_to_vec().ok()?;
     std::fs::create_dir_all(dir).ok()?;
     std::fs::write(&path, body).ok()?;
@@ -100,7 +100,7 @@ fn fetch(dir: &Path, id: &str, url: &str) -> Option<String> {
 
 /// The icon already on disk, if it is.
 fn cached(dir: &Path, id: &str) -> Option<String> {
-    let path = dir.join(format!("{id}.svg"));
+    let path = cacp_agents::contained(dir, &format!("{id}.svg")).ok()?;
     path.exists().then(|| path.to_str())?.map(str::to_owned)
 }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -106,6 +106,11 @@ fn cached(dir: &Path, id: &str) -> Option<String> {
 
 // ── the catalog, for the settings window ─────────────────────────
 
+/// The catalog takes any publisher who submits one, and each entry is an npm
+/// package this machine would download and run. These are the adapters whose
+/// authors are the labs that build the models.
+const ALLOWED: [&str; 4] = ["claude-acp", "codex-acp", "gemini", "antigravity-acp"];
+
 /// One row of the agents section: what the registry publishes, and whether it
 /// is on this machine.
 pub struct Listing {
@@ -130,6 +135,7 @@ pub fn listings() -> Vec<Listing> {
     catalog
         .agents
         .into_iter()
+        .filter(|agent| ALLOWED.contains(&agent.id.as_str()))
         .map(|agent| {
             let installed = Installed::find(&data, &agent.id).map(|found| found.version);
             let icon = cached(&dir, &agent.id).map(SharedString::from);
@@ -154,6 +160,9 @@ pub fn prefetch_icons() {
     };
     let dir = cache.join("icons");
     for agent in &catalog.agents {
+        if !ALLOWED.contains(&agent.id.as_str()) {
+            continue;
+        }
         if let Some(url) = agent.icon.as_deref() {
             fetch(&dir, &agent.id, url);
         }

--- a/src/model/article.rs
+++ b/src/model/article.rs
@@ -19,8 +19,8 @@ use bezel::{
 use editor::Editor;
 use markdown::Typography;
 use std::{
+    cmp::Reverse,
     path::{Path, PathBuf},
-    time::UNIX_EPOCH,
 };
 
 /// What articles were called before they were named for their age, and what an
@@ -213,7 +213,7 @@ pub fn list(project: &Path) -> Vec<Article> {
         .map(|entry| entry.path().join(CONTENT))
         .filter(|path| path.is_file())
         .collect();
-    paths.sort();
+    paths.sort_by_key(|path| Reverse(project::written(path)));
     paths.into_iter().map(Article::new).collect()
 }
 
@@ -235,16 +235,6 @@ fn free(dir: &Path, stamp: u128) -> PathBuf {
         .unwrap_or_else(|| dir.join(stamp.to_string()))
 }
 
-/// When this file was last written, for an article being given the id it should
-/// have been made with.
-fn written(path: &Path) -> u128 {
-    std::fs::metadata(path)
-        .and_then(|meta| meta.modified())
-        .ok()
-        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
-        .map_or_else(project::stamp, |since| since.as_millis())
-}
-
 /// Articles used to sit loose in `.cydonia/` as `foo.md` beside `foo.cover-N.svg`,
 /// and the stem was the name the sidebar showed. Give each one a directory of
 /// its own age, and keep that stem by writing it in as the title it was.
@@ -263,7 +253,7 @@ fn migrate(dir: &Path) {
         let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
             continue;
         };
-        let to = free(&dir.join(DIR), written(path));
+        let to = free(&dir.join(DIR), project::written(path));
         if std::fs::create_dir_all(&to).is_err() {
             continue;
         }

--- a/src/model/board.rs
+++ b/src/model/board.rs
@@ -15,7 +15,10 @@
 
 use crate::model::project;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::{
+    cmp::Reverse,
+    path::{Path, PathBuf},
+};
 
 /// Where a project's boards live, and what the one board a project used to be
 /// allowed was called.
@@ -134,8 +137,7 @@ impl Spot {
     }
 }
 
-/// This project's boards, oldest first — the file names are stamps, so sorting
-/// them is sorting by age.
+/// This project's boards, most recently written first.
 pub fn list(project: &Path) -> Vec<Board> {
     let dir = project::dir(project);
     migrate(&dir);
@@ -147,7 +149,7 @@ pub fn list(project: &Path) -> Vec<Board> {
         .map(|entry| entry.path())
         .filter(|path| path.extension().is_some_and(|ext| ext == "toml"))
         .collect();
-    paths.sort();
+    paths.sort_by_key(|path| Reverse(project::written(path)));
     paths.into_iter().filter_map(read).collect()
 }
 

--- a/src/model/project.rs
+++ b/src/model/project.rs
@@ -144,6 +144,16 @@ pub fn stamp() -> u128 {
         .unwrap_or_default()
 }
 
+/// When a file was last written, as the same millisecond stamp ids carry — the
+/// key entries are listed by, so the one you touched last is the one on top.
+pub fn written(path: &Path) -> u128 {
+    std::fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map_or_else(stamp, |since| since.as_millis())
+}
+
 pub fn dir(project: &Path) -> PathBuf {
     project.join(DIR)
 }

--- a/src/model/record.rs
+++ b/src/model/record.rs
@@ -10,6 +10,7 @@
 use crate::model::{project, session::ChatItem};
 use serde::{Deserialize, Serialize};
 use std::{
+    cmp::Reverse,
     path::{Path, PathBuf},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -47,8 +48,8 @@ fn dir(project: &Path) -> PathBuf {
     project::dir(project).join(SESSIONS)
 }
 
-/// Every session filed in the project with the file it came from, oldest
-/// first. The path is what lets a row rewrite or delete itself later.
+/// Every session filed in the project with the file it came from, most recently
+/// updated first. The path is what lets a row rewrite or delete itself later.
 pub fn list(project: &Path) -> Vec<(PathBuf, Record)> {
     let Ok(entries) = std::fs::read_dir(dir(project)) else {
         return Vec::new();
@@ -62,7 +63,7 @@ pub fn list(project: &Path) -> Vec<(PathBuf, Record)> {
             Some((path, serde_json::from_str(&body).ok()?))
         })
         .collect();
-    found.sort_by_key(|(_, record)| record.updated);
+    found.sort_by_key(|(_, record)| Reverse(record.updated));
     found
 }
 

--- a/src/model/session.rs
+++ b/src/model/session.rs
@@ -508,7 +508,7 @@ impl ChatSession {
         });
     }
 
-    fn notice(&mut self, failed: bool, text: &str) {
+    pub(crate) fn notice(&mut self, failed: bool, text: &str) {
         self.items.push(ChatItem::Notice {
             text: text.to_owned(),
             failed,

--- a/src/model/settings.rs
+++ b/src/model/settings.rs
@@ -35,10 +35,12 @@ impl Default for Settings {
             args: vec!["-y".into(), pkg.into()],
             env: BTreeMap::new(),
         };
+        // `npx` resolves a dist-tag against the npm registry on every launch,
+        // so these carry the version the ACP registry pins.
         Self {
             agents: vec![
-                npx("claude", "@agentclientprotocol/claude-agent-acp@latest"),
-                npx("codex", "@agentclientprotocol/codex-acp@latest"),
+                npx("claude", "@agentclientprotocol/claude-agent-acp@0.73.0"),
+                npx("codex", "@agentclientprotocol/codex-acp@1.8.0"),
             ],
         }
     }

--- a/src/model/settings.rs
+++ b/src/model/settings.rs
@@ -7,6 +7,11 @@ use std::{collections::BTreeMap, path::PathBuf};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Settings {
+    /// Whether agents may be launched. Off until asked for: every agent is a
+    /// JS package this machine downloads and runs. Declared above `agents`
+    /// because a bare key after `[[agents]]` would belong to that table.
+    #[serde(default)]
+    pub agents_enabled: bool,
     #[serde(default)]
     pub agents: Vec<Agent>,
 }
@@ -26,6 +31,29 @@ pub struct Agent {
     pub env: BTreeMap<String, String>,
 }
 
+/// The launchers that resolve a package name on every run. An installed
+/// agent's command is a path to an unpacked executable, which resolves nothing.
+const RUNNERS: [&str; 3] = ["npx", "bunx", "pnpx"];
+
+impl Agent {
+    /// Whether every npm package this entry names carries an exact version.
+    /// `npx pkg@latest` resolves against the registry on every launch, which is
+    /// a different program each time.
+    pub fn pinned(&self) -> bool {
+        if !RUNNERS.contains(&self.command.as_str()) {
+            return true;
+        }
+        self.args
+            .iter()
+            .filter(|arg| !arg.starts_with('-'))
+            .all(|spec| {
+                let name = cacp_agents::package_name(spec);
+                spec.len() > name.len()
+                    && spec[name.len() + 1..].starts_with(|c: char| c.is_ascii_digit())
+            })
+    }
+}
+
 impl Default for Settings {
     fn default() -> Self {
         let npx = |name: &str, pkg: &str| Agent {
@@ -38,6 +66,7 @@ impl Default for Settings {
         // `npx` resolves a dist-tag against the npm registry on every launch,
         // so these carry the version the ACP registry pins.
         Self {
+            agents_enabled: false,
             agents: vec![
                 npx("claude", "@agentclientprotocol/claude-agent-acp@0.73.0"),
                 npx("codex", "@agentclientprotocol/codex-acp@1.8.0"),
@@ -91,7 +120,26 @@ pub fn load() -> Result<Settings> {
         return Ok(settings);
     }
     let content = std::fs::read_to_string(&path)?;
-    toml::from_str(&content).with_context(|| format!("invalid settings: {}", path.display()))
+    let mut settings: Settings = toml::from_str(&content)
+        .with_context(|| format!("invalid settings: {}", path.display()))?;
+    // A floating tag is a different program on every launch. The line stays in
+    // the file, where it can be read and fixed; it just never launches.
+    settings.agents.retain(Agent::pinned);
+    Ok(settings)
+}
+
+/// Turn the agent gate on or off in the file.
+///
+/// Edited with `toml_edit` for the reason [`put_agent`] is: the file is meant
+/// to be opened by hand, and a round trip would drop every comment in it.
+pub fn set_agents_enabled(on: bool) -> Result<()> {
+    let path = dir()?.join("settings.toml");
+    let body = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut doc: toml_edit::DocumentMut =
+        body.parse().context("settings.toml is not valid toml")?;
+    doc["agents_enabled"] = toml_edit::value(on);
+    std::fs::write(&path, doc.to_string())?;
+    Ok(())
 }
 
 /// Put `agent` in the file, replacing whichever entry already launches it.

--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -21,6 +21,8 @@ pub struct State {
     /// Whether the frost is off — bezel paints opaque surfaces instead.
     #[serde(default)]
     pub reduce_transparency: bool,
+    /// Whether the text caret blinks. Off holds it lit.
+    pub cursor_blink: bool,
     /// The body size the type ladder is scaled against, in points.
     pub text_size: f32,
     /// The greys' oklch hue in degrees, and how much of it they carry. Zero
@@ -44,6 +46,7 @@ impl Default for State {
             active: 0,
             appearance: AppearanceMode::default(),
             reduce_transparency: false,
+            cursor_blink: true,
             text_size: TextStyle::Body.size(),
             hue: 0.,
             chroma: 0.,
@@ -77,6 +80,7 @@ pub fn restore() -> State {
         active,
         appearance: stored.appearance,
         reduce_transparency: stored.reduce_transparency,
+        cursor_blink: stored.cursor_blink,
         text_size: stored.text_size.clamp(TEXT_SIZE.0, TEXT_SIZE.1),
         hue: stored.hue,
         chroma: stored.chroma,

--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -7,7 +7,27 @@
 use crate::model::settings;
 use bezel::theme::{TextStyle, appearance::AppearanceMode};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{collections::BTreeMap, path::PathBuf};
+
+/// The four things a project holds. Which one a launch lands on is the last
+/// one that was open, so the window comes back where it was left.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Kind {
+    Session,
+    Board,
+    Article,
+    Table,
+}
+
+/// One remembered entry: which kind, and which of them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Entry {
+    pub kind: Kind,
+    /// The file the entry is, or a table's key. An index would drift as
+    /// siblings are added and removed between launches.
+    pub id: String,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
@@ -29,6 +49,11 @@ pub struct State {
     /// chroma is the shipped neutral, whatever the hue says.
     pub hue: f32,
     pub chroma: f32,
+    /// What each project was last showing, by project path. Last in the struct
+    /// because a map renders as TOML tables, and a bare key after one of those
+    /// belongs to it.
+    #[serde(default)]
+    pub last: BTreeMap<PathBuf, Entry>,
 }
 
 /// What the body size may be set to, in points: the ladder's smallest measured
@@ -50,6 +75,7 @@ impl Default for State {
             text_size: TextStyle::Body.size(),
             hue: 0.,
             chroma: 0.,
+            last: BTreeMap::new(),
         }
     }
 }
@@ -84,6 +110,7 @@ pub fn restore() -> State {
         text_size: stored.text_size.clamp(TEXT_SIZE.0, TEXT_SIZE.1),
         hue: stored.hue,
         chroma: stored.chroma,
+        last: stored.last,
     }
 }
 

--- a/src/model/state.rs
+++ b/src/model/state.rs
@@ -18,7 +18,7 @@ pub struct State {
     pub active: usize,
     #[serde(default)]
     pub appearance: AppearanceMode,
-    /// Whether the frost is off — bezel paints opaque surfaces instead.
+    /// Whether the vibrancy is off — bezel composites the window opaque.
     #[serde(default)]
     pub reduce_transparency: bool,
     /// Whether the text caret blinks. Off holds it lit.

--- a/src/model/workspace.rs
+++ b/src/model/workspace.rs
@@ -77,15 +77,19 @@ impl Workspace {
         for ix in restore {
             this.restore_sessions(ix);
         }
-        this.open_first_session(cx);
+        this.open_last_session(cx);
         this.load_agent_icons(cx);
         // Temporary dev hook: `CYDONIA_TEST_PROMPT` sends a prompt on launch
         // so a turn can be verified without a composer. Here rather than on
         // connect, which a resume would fire again.
-        if let Ok(prompt) = std::env::var("CYDONIA_TEST_PROMPT")
-            && let Some(id) = this.active_id()
-        {
-            this.send(id, prompt, cx);
+        if let Ok(prompt) = std::env::var("CYDONIA_TEST_PROMPT") {
+            let id = this.active_id().or_else(|| {
+                let entry = this.settings.agents.first().cloned()?;
+                this.new_session(entry, None, cx)
+            });
+            if let Some(id) = id {
+                this.send(id, prompt, cx);
+            }
         }
         this
     }
@@ -178,18 +182,22 @@ impl Workspace {
 
     // ── projects ─────────────────────────────────────────────────────
 
+    /// A project just added starts talking to an agent; one already on the
+    /// rail is only brought forward.
     pub fn open_project(&mut self, path: PathBuf, cx: &mut Context<Self>) {
-        let open = self.projects.iter().position(|p| p.path == path);
-        let ix = match open {
-            Some(ix) => ix,
-            None => {
-                self.projects.push(Project::new(path));
-                let ix = self.projects.len() - 1;
-                self.restore_sessions(ix);
-                ix
-            }
-        };
+        if let Some(ix) = self.projects.iter().position(|p| p.path == path) {
+            self.select_project(ix, cx);
+            return;
+        }
+        self.projects.push(Project::new(path));
+        let ix = self.projects.len() - 1;
+        self.restore_sessions(ix);
         self.select_project(ix, cx);
+        if self.projects[ix].sessions.is_empty()
+            && let Some(entry) = self.settings.agents.first().cloned()
+        {
+            self.new_session(entry, None, cx);
+        }
     }
 
     pub fn select_project(&mut self, ix: usize, cx: &mut Context<Self>) {
@@ -197,7 +205,7 @@ impl Workspace {
             return;
         }
         self.active = Some(ix);
-        self.open_first_session(cx);
+        self.open_last_session(cx);
         self.save();
         cx.notify();
     }
@@ -213,18 +221,14 @@ impl Workspace {
             let next = if active > ix { active - 1 } else { active };
             (!self.projects.is_empty()).then(|| next.min(self.projects.len() - 1))
         });
-        self.open_first_session(cx);
+        self.open_last_session(cx);
         self.save();
         cx.notify();
     }
 
-    /// A project talks to an agent the moment it is looked at: the tab in
-    /// front opens its first session, and the tabs behind it spawn nothing.
-    ///
-    /// A project with sessions read back from disk shows its most recent one
-    /// rather than opening a second beside it — nothing there is connected
-    /// until something is sent to it.
-    fn open_first_session(&mut self, cx: &mut Context<Self>) {
+    /// The project in front shows its most recent session; nothing there is
+    /// connected until something is sent to it.
+    fn open_last_session(&mut self, cx: &mut Context<Self>) {
         let Some(project) = self.active.and_then(|ix| self.projects.get_mut(ix)) else {
             return;
         };
@@ -234,10 +238,6 @@ impl Workspace {
         if let Some(id) = project.sessions.last().map(|chat| chat.id) {
             project.active = Some(id);
             cx.notify();
-            return;
-        }
-        if let Some(entry) = self.settings.agents.first().cloned() {
-            self.new_session(entry, None, cx);
         }
     }
 

--- a/src/model/workspace.rs
+++ b/src/model/workspace.rs
@@ -24,6 +24,7 @@ use crate::{
 use bezel::{
     gpui::{App, Context, EntityId, SharedString},
     theme::{self, Brand, Theme, Tint, appearance::AppearanceMode},
+    ui::input,
 };
 use std::{
     collections::HashMap,
@@ -42,6 +43,7 @@ pub struct Workspace {
     pub active: Option<usize>,
     pub appearance: AppearanceMode,
     pub reduce_transparency: bool,
+    pub cursor_blink: bool,
     /// Session ids are minted here and never reused, so a card's link to the
     /// session it opened stays unambiguous for the life of the process.
     next_id: u64,
@@ -68,6 +70,7 @@ impl Workspace {
             active,
             appearance: state.appearance,
             reduce_transparency: state.reduce_transparency,
+            cursor_blink: state.cursor_blink,
             text_size: state.text_size,
             tint: Tint::new(state.hue, state.chroma),
             meter: false,
@@ -100,6 +103,7 @@ impl Workspace {
             active: self.active.unwrap_or_default(),
             appearance: self.appearance,
             reduce_transparency: self.reduce_transparency,
+            cursor_blink: self.cursor_blink,
             text_size: self.text_size,
             hue: self.tint.hue,
             chroma: self.tint.chroma,
@@ -162,6 +166,14 @@ impl Workspace {
     pub fn set_reduce_transparency(&mut self, reduce: bool, cx: &mut Context<Self>) {
         self.reduce_transparency = reduce;
         apply_transparency(reduce, cx);
+        self.save();
+        cx.notify();
+    }
+
+    /// The caret is bezel's, so the setting is: nothing here reads it back.
+    pub fn set_cursor_blink(&mut self, blink: bool, cx: &mut Context<Self>) {
+        self.cursor_blink = blink;
+        input::set_caret_blink(blink, cx);
         self.save();
         cx.notify();
     }
@@ -795,11 +807,16 @@ pub fn apply_tint(tint: Tint, cx: &mut App) {
     );
 }
 
+/// Two answers, because bezel asks two questions: the window stops compositing
+/// translucent, and the frost over it goes opaque. Chrome keeps its layers —
+/// an opaque window carrying them is what this setting asks for, and what the
+/// system's own does not do.
 pub fn apply_transparency(reduce: bool, cx: &mut App) {
     let glass = if reduce { 1.0 } else { Theme::GLASS_ALPHA };
     theme::set_brand(
         Brand {
             glass,
+            vibrancy: !reduce,
             ..theme::brand(cx)
         },
         cx,

--- a/src/model/workspace.rs
+++ b/src/model/workspace.rs
@@ -812,10 +812,10 @@ pub fn apply_tint(tint: Tint, cx: &mut App) {
 /// an opaque window carrying them is what this setting asks for, and what the
 /// system's own does not do.
 pub fn apply_transparency(reduce: bool, cx: &mut App) {
-    let glass = if reduce { 1.0 } else { Theme::GLASS_ALPHA };
+    let alpha = if reduce { 1.0 } else { Theme::VIBRANCY_ALPHA };
     theme::set_brand(
         Brand {
-            glass,
+            vibrancy_alpha: alpha,
             vibrancy: !reduce,
             ..theme::brand(cx)
         },

--- a/src/model/workspace.rs
+++ b/src/model/workspace.rs
@@ -170,6 +170,18 @@ impl Workspace {
         cx.notify();
     }
 
+    /// Let agents run, or stop them running. Written through to `settings.toml`
+    /// rather than app state: it is the file the gate is read back from.
+    /// A failed write leaves both halves alone, so the switch stays where it
+    /// was rather than claiming a gate the file does not carry.
+    pub fn set_agents_enabled(&mut self, on: bool, cx: &mut Context<Self>) {
+        if settings::set_agents_enabled(on).is_err() {
+            return;
+        }
+        self.settings.agents_enabled = on;
+        cx.notify();
+    }
+
     /// The caret is bezel's, so the setting is: nothing here reads it back.
     pub fn set_cursor_blink(&mut self, blink: bool, cx: &mut Context<Self>) {
         self.cursor_blink = blink;
@@ -266,12 +278,18 @@ impl Workspace {
 
     /// Open a session in the active project. `seed` is its first prompt, sent
     /// as soon as the agent is up — what a dispatched card rides in on.
+    ///
+    /// The one place a session is born, so it is where the agent gate bites:
+    /// nothing spawns an agent until the user has turned agents on.
     pub fn new_session(
         &mut self,
         entry: settings::Agent,
         seed: Option<String>,
         cx: &mut Context<Self>,
     ) -> Option<u64> {
+        if !self.settings.agents_enabled {
+            return None;
+        }
         let ix = self.active?;
         let id = self.next_id;
         self.next_id += 1;
@@ -333,6 +351,9 @@ impl Workspace {
     /// Send to a session, starting an agent for it when it has none — typing
     /// into a session read back from disk is what picks it up again.
     pub fn send(&mut self, id: u64, content: String, cx: &mut Context<Self>) {
+        // Read before `chat` borrows the projects. This is the second place an
+        // agent process starts, so it is the second half of the gate.
+        let enabled = self.settings.agents_enabled;
         let found = self
             .projects
             .iter_mut()
@@ -340,6 +361,16 @@ impl Workspace {
         let Some(chat) = found else {
             return;
         };
+        // Said out loud rather than queued: with no agent to drain it, a
+        // prompt pushed onto the queue reads as a message that went nowhere.
+        if !enabled && !chat.live() {
+            chat.notice(
+                true,
+                "agents are disabled — turn them on in Settings › Agents",
+            );
+            cx.notify();
+            return;
+        }
         if chat.idle() && chat.resumable() {
             chat.resume(cx);
         }

--- a/src/model/workspace.rs
+++ b/src/model/workspace.rs
@@ -794,7 +794,7 @@ impl Workspace {
     }
 }
 
-/// Point bezel's frost alpha at the preference. Free rather than a method
+/// Point bezel's tint at the preference. Free rather than a method
 /// because the window reads its background appearance while it is being opened,
 /// which is before there is a workspace to ask.
 pub fn apply_tint(tint: Tint, cx: &mut App) {
@@ -808,7 +808,7 @@ pub fn apply_tint(tint: Tint, cx: &mut App) {
 }
 
 /// Two answers, because bezel asks two questions: the window stops compositing
-/// translucent, and the frost over it goes opaque. Chrome keeps its layers —
+/// translucent, and the tint over it goes opaque. Chrome keeps its layers —
 /// an opaque window carrying them is what this setting asks for, and what the
 /// system's own does not do.
 pub fn apply_transparency(reduce: bool, cx: &mut App) {

--- a/src/model/workspace.rs
+++ b/src/model/workspace.rs
@@ -27,7 +27,7 @@ use bezel::{
     ui::input,
 };
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     path::{Path, PathBuf},
 };
 
@@ -57,6 +57,9 @@ pub struct Workspace {
     /// The registry's mark for each configured agent, by name. Empty until the
     /// catalog lands, and stays empty offline.
     agent_icons: HashMap<String, SharedString>,
+    /// What each project was last showing, by project path — where a launch
+    /// puts you back.
+    last: BTreeMap<PathBuf, state::Entry>,
 }
 
 impl Workspace {
@@ -76,11 +79,12 @@ impl Workspace {
             meter: false,
             next_id: 0,
             agent_icons: HashMap::new(),
+            last: state.last,
         };
         for ix in restore {
             this.restore_sessions(ix);
         }
-        this.open_last_session(cx);
+        this.open_last_entry(cx);
         this.load_agent_icons(cx);
         // Temporary dev hook: `CYDONIA_TEST_PROMPT` sends a prompt on launch
         // so a turn can be verified without a composer. Here rather than on
@@ -107,6 +111,7 @@ impl Workspace {
             text_size: self.text_size,
             hue: self.tint.hue,
             chroma: self.tint.chroma,
+            last: self.last.clone(),
         });
     }
 
@@ -229,7 +234,7 @@ impl Workspace {
             return;
         }
         self.active = Some(ix);
-        self.open_last_session(cx);
+        self.open_last_entry(cx);
         self.save();
         cx.notify();
     }
@@ -245,24 +250,74 @@ impl Workspace {
             let next = if active > ix { active - 1 } else { active };
             (!self.projects.is_empty()).then(|| next.min(self.projects.len() - 1))
         });
-        self.open_last_session(cx);
+        self.open_last_entry(cx);
         self.save();
         cx.notify();
     }
 
-    /// The project in front shows its most recent session; nothing there is
-    /// connected until something is sent to it.
-    fn open_last_session(&mut self, cx: &mut Context<Self>) {
-        let Some(project) = self.active.and_then(|ix| self.projects.get_mut(ix)) else {
+    /// Put the project in front back where it was left — the entry it was last
+    /// showing, of whichever kind. Nothing is connected by it: a session opened
+    /// this way stays idle until something is sent to it.
+    ///
+    /// The remembered entry is found by its own identity rather than by
+    /// position, because a sibling added or removed between launches shifts
+    /// every index after it.
+    fn open_last_entry(&mut self, cx: &mut Context<Self>) {
+        let Some(ix) = self.active else {
             return;
         };
-        if project.active.is_some() {
+        let Some(entry) = self
+            .projects
+            .get(ix)
+            .and_then(|open| self.last.get(&open.path))
+        else {
             return;
+        };
+        let (kind, id) = (entry.kind, entry.id.clone());
+        let Some(project) = self.projects.get_mut(ix) else {
+            return;
+        };
+        let at = |path: Option<&Path>| path.is_some_and(|path| path.to_string_lossy() == id);
+        match kind {
+            state::Kind::Session => {
+                project.active = project
+                    .sessions
+                    .iter()
+                    .find(|chat| at(chat.file.as_deref()))
+                    .map(|chat| chat.id);
+            }
+            state::Kind::Board => {
+                project.board = project
+                    .boards
+                    .iter()
+                    .position(|board| at(Some(&board.path)));
+            }
+            state::Kind::Article => {
+                project.article = project
+                    .articles
+                    .iter()
+                    .position(|article| at(Some(&article.path)));
+                if let Some(at) = project.article {
+                    project.articles[at].open(cx);
+                }
+            }
+            state::Kind::Table => {
+                project.table = project.tables.iter().position(|table| table.key == id);
+                project.reload_page();
+            }
         }
-        if let Some(id) = project.sessions.last().map(|chat| chat.id) {
-            project.active = Some(id);
-            cx.notify();
-        }
+        cx.notify();
+    }
+
+    /// Remember the entry a project is now showing, so the next launch lands on
+    /// it. Every way of opening one arrives here.
+    fn remember(&mut self, project: usize, kind: state::Kind, id: String) {
+        let Some(open) = self.projects.get(project) else {
+            return;
+        };
+        self.last
+            .insert(open.path.clone(), state::Entry { kind, id });
+        self.save();
     }
 
     pub fn active_project(&self) -> Option<&Project> {
@@ -308,9 +363,18 @@ impl Workspace {
             return;
         };
         self.projects[ix].active = Some(id);
-        if self.active != Some(ix) {
-            self.active = Some(ix);
-            self.save();
+        self.active = Some(ix);
+        // A session has no file until its first turn is written, so one that
+        // has said nothing is not yet somewhere to come back to.
+        if let Some(file) = self.projects[ix]
+            .session(id)
+            .and_then(|chat| chat.file.clone())
+        {
+            self.remember(
+                ix,
+                state::Kind::Session,
+                file.to_string_lossy().into_owned(),
+            );
         }
         cx.notify();
     }
@@ -375,6 +439,14 @@ impl Workspace {
             chat.resume(cx);
         }
         chat.send(content);
+        let file = chat.file.clone();
+        if let (Some(file), Some(ix)) = (file, self.project_of(id)) {
+            self.remember(
+                ix,
+                state::Kind::Session,
+                file.to_string_lossy().into_owned(),
+            );
+        }
         cx.notify();
     }
 
@@ -403,7 +475,7 @@ impl Workspace {
         }
         project.sessions.retain(|chat| chat.id != id);
         if project.active == Some(id) {
-            project.active = project.sessions.last().map(|chat| chat.id);
+            project.active = project.sessions.first().map(|chat| chat.id);
         }
         cx.notify();
     }
@@ -472,10 +544,9 @@ impl Workspace {
             return;
         }
         open.board = Some(ix);
-        if self.active != Some(project) {
-            self.active = Some(project);
-            self.save();
-        }
+        let id = open.boards[ix].path.to_string_lossy().into_owned();
+        self.active = Some(project);
+        self.remember(project, state::Kind::Board, id);
         cx.notify();
     }
 
@@ -549,10 +620,12 @@ impl Workspace {
         };
         article.open(cx);
         self.projects[project].article = Some(ix);
-        if self.active != Some(project) {
-            self.active = Some(project);
-            self.save();
-        }
+        let id = self.projects[project].articles[ix]
+            .path
+            .to_string_lossy()
+            .into_owned();
+        self.active = Some(project);
+        self.remember(project, state::Kind::Article, id);
         cx.notify();
     }
 
@@ -650,10 +723,9 @@ impl Workspace {
         }
         open.table = Some(ix);
         open.reload_page();
-        if self.active != Some(project) {
-            self.active = Some(project);
-            self.save();
-        }
+        let id = open.tables[ix].key.clone();
+        self.active = Some(project);
+        self.remember(project, state::Kind::Table, id);
         cx.notify();
     }
 

--- a/src/view/article.rs
+++ b/src/view/article.rs
@@ -335,11 +335,6 @@ impl Cydonia {
         let id = SharedString::from(format!("article-{project}-{ix}"));
 
         sidebar::row(id, "article-row", selected, &theme)
-            .py(px(6.))
-            .flex()
-            .flex_row()
-            .items_center()
-            .gap(px(8.))
             .child(
                 icons::icon(icons::DOCUMENT)
                     .size(px(14.))

--- a/src/view/article.rs
+++ b/src/view/article.rs
@@ -12,8 +12,13 @@ use bezel::{
         self, AnyElement, App, Context, CursorStyle, Entity, Focusable as _, KeyBinding, ObjectFit,
         PathPromptOptions, SharedString, Window, actions, div, img, prelude::*, px,
     },
-    theme::{TextStyle, Theme, Typeset},
-    ui::{icons, input::TextField},
+    motion::{Fade, Painter},
+    theme::{ControlSize, Sizing as _, TextStyle, Theme, Typeset},
+    ui::{
+        icons,
+        input::TextField,
+        widgets::{ButtonStyle, Buttons as _},
+    },
 };
 use std::path::PathBuf;
 
@@ -267,34 +272,19 @@ impl Cydonia {
     /// down the moment the mouse crossed the pane.
     fn cover_controls(&self, has_cover: bool, cx: &Context<Self>) -> impl IntoElement + use<> {
         let theme = Theme::of(cx).clone();
+        let painter = Painter::of(cx);
         let chip = |id: &'static str, label: &'static str| {
-            div()
+            theme
+                .button(label, ButtonStyle::Ghost, Some(Fade::new(painter, id)))
+                .control_size(ControlSize::Small)
                 .id(id)
-                .px(px(8.))
-                .py(px(3.))
-                .rounded(px(Theme::control_radius()))
-                .text_style(TextStyle::Subheadline)
-                .text_color(theme.text_muted)
-                .hover(|chip| chip.bg(theme.element_hover).text_color(theme.text))
-                .child(label)
         };
 
-        div()
+        theme
+            .control_group()
             .absolute()
             .bottom(px(10.))
             .right(px(10.))
-            .flex()
-            .flex_row()
-            .items_center()
-            .gap(px(2.))
-            .p(px(2.))
-            .rounded(px(Theme::control_radius()))
-            // Its own plate, because what it sits on is a picture we did not
-            // choose: on the cover's own colours there is no text tone that
-            // stays legible without one.
-            .bg(theme.surface_raised)
-            .border_1()
-            .border_color(theme.border)
             .invisible()
             .group_hover("cover", |row| row.visible())
             .child(

--- a/src/view/detail.rs
+++ b/src/view/detail.rs
@@ -5,7 +5,7 @@ use crate::{
     model::session::{ChatSession, PlanStatus},
     view::{
         component::{composer, transcript},
-        root::{self, Cydonia, Pane},
+        root::{self, Cydonia, NewSession, Pane},
     },
 };
 use bezel::{
@@ -109,13 +109,13 @@ impl Cydonia {
     ) -> impl IntoElement + use<> {
         let theme = Theme::of(cx).clone();
         let open = self.workspace.read(cx).active_project().is_some();
-        // Nothing to send to: the session's agent is gone from settings.toml,
-        // so there is nothing left to reconnect it to.
+        // Nothing to send to: no session at all, or one whose agent has gone
+        // from settings.toml, leaving nothing to reconnect it to.
         let live = self
             .workspace
             .read(cx)
             .active_session()
-            .is_none_or(ChatSession::resumable);
+            .is_some_and(ChatSession::resumable);
         let showing = self.showing(cx);
         let body = if !open {
             self.no_project(cx)
@@ -182,20 +182,117 @@ impl Cydonia {
                 column.child(self.fold_cluster(window, cx))
             })
     }
+}
 
-    /// The session in front, or the invitation to open one.
+/// The invitation's rows as one block: left-aligned so every glyph lands on the
+/// same edge, and held off the line above it — `empty_state` centres its
+/// children, which would otherwise centre each row on its own width.
+fn make_list(rows: impl IntoIterator<Item = AnyElement>) -> impl IntoElement {
+    div()
+        .mt(px(14.))
+        .flex()
+        .flex_col()
+        .items_start()
+        .gap(px(8.))
+        .children(rows)
+}
+
+impl Cydonia {
+    /// What to do when there is nothing to show: open a project, or make the
+    /// first entry in the one that is open. The kinds are listed rather than
+    /// named in a hint, because a list can be clicked.
+    fn nothing_open(&self, cx: &mut Context<Self>) -> AnyElement {
+        let theme = Theme::of(cx).clone();
+        let workspace = self.workspace.read(cx);
+        let Some(ix) = workspace.active else {
+            return self.no_project(cx);
+        };
+        let agents = workspace.settings.agents_enabled;
+        let name = workspace
+            .projects
+            .get(ix)
+            .map(|project| shown_path(&project.path))
+            .unwrap_or_default();
+        let session = agents.then(|| {
+            self.make_row(
+                "session",
+                "New session",
+                icons::CHAT_ROUND_LINE,
+                cx,
+                move |this, window, cx| this.new_session_action(&NewSession, window, cx),
+            )
+        });
+        theme
+            .empty_state(icons::FOLDER, "Nothing open", format!("in {name}"))
+            .flex_1()
+            .child(make_list(session.into_iter().chain([
+                self.make_row("board", "New board", icons::LIST, cx, move |this, _, cx| {
+                    this.new_board(ix, cx)
+                }),
+                self.make_row(
+                    "article",
+                    "New article",
+                    icons::DOCUMENT_ADD,
+                    cx,
+                    move |this, window, cx| this.new_article(ix, window, cx),
+                ),
+                self.make_row(
+                    "table",
+                    "New table",
+                    icons::WIDGET,
+                    cx,
+                    move |this, _, cx| this.new_table(ix, cx),
+                ),
+            ])))
+            .into_any_element()
+    }
+
+    /// One line of the invitation: a glyph, a label, and what it makes.
+    fn make_row(
+        &self,
+        id: &'static str,
+        label: &'static str,
+        glyph: &'static str,
+        cx: &mut Context<Self>,
+        make: impl Fn(&mut Self, &mut Window, &mut Context<Self>) + 'static,
+    ) -> AnyElement {
+        let theme = Theme::of(cx).clone();
+        // An svg paints in its own `text_color` and inherits none, so the glyph
+        // cannot ride the row's hover. Both halves take the row's group instead,
+        // which lights them together — the group is named per row so hovering
+        // one does not light the rest.
+        div()
+            .id(id)
+            .group(id)
+            .flex()
+            .items_center()
+            .gap(px(8.))
+            .cursor_pointer()
+            .text_style(TextStyle::Callout)
+            .child(
+                icons::icon(glyph)
+                    .size(px(14.))
+                    .flex_none()
+                    .text_color(theme.text_muted)
+                    .group_hover(id, |el| el.text_color(theme.text)),
+            )
+            .child(
+                div()
+                    .text_color(theme.text_muted)
+                    .group_hover(id, |el| el.text_color(theme.text))
+                    .child(label),
+            )
+            .on_click(cx.listener(move |this, _, window, cx| make(this, window, cx)))
+            .into_any_element()
+    }
+
+    /// The session in front, or — because the conversation is what stands in
+    /// when a project has nothing else open — the way to make something.
     fn conversation(&self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
         let theme = Theme::of(cx).clone();
         let workspace = self.workspace.read(cx);
         let Some(chat) = workspace.active_session() else {
-            return theme
-                .empty_state(
-                    icons::CHAT_ROUND_LINE,
-                    "No session",
-                    "⌘N to start one in this project.",
-                )
-                .flex_1()
-                .into_any_element();
+            return self.nothing_open(cx);
         };
         // Nothing has been said yet, so what the session has to show for
         // itself is the directory the agent was started in.

--- a/src/view/root.rs
+++ b/src/view/root.rs
@@ -11,14 +11,15 @@ use crate::{
             meter,
         },
         settings::{self, Section, SettingsWindow},
-        sidebar::Renaming,
+        sidebar::{Renaming, Row},
         table,
     },
 };
 use bezel::{
     gpui::{
         self, AnyElement, App, Axis, Context, DragMoveEvent, Empty, Entity, Hsla, KeyBinding,
-        PathPromptOptions, Render, Window, WindowHandle, actions, div, prelude::*, px,
+        PathPromptOptions, Render, UniformListScrollHandle, Window, WindowHandle, actions, div,
+        prelude::*, px,
     },
     motion::{Fade, Painter},
     theme::{Appearance, Material, SurfaceStyle, TextStyle, Theme, Typeset},
@@ -38,7 +39,9 @@ actions!(
         OpenProject,
         OpenSettings,
         CommitName,
-        DismissName
+        DismissName,
+        NextEntry,
+        PrevEntry
     ]
 );
 
@@ -150,6 +153,11 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("cmd-o", OpenProject, None),
         // What macOS binds Preferences to in every other app.
         KeyBinding::new("cmd-,", OpenSettings, None),
+        // What a browser binds its tabs to. Global, because the point is to
+        // move between documents without taking the hand out of the editor —
+        // where `tab` itself is indent.
+        KeyBinding::new("ctrl-tab", NextEntry, None),
+        KeyBinding::new("ctrl-shift-tab", PrevEntry, None),
         KeyBinding::new("enter", CommitName, Some(RENAME_CONTEXT)),
         KeyBinding::new("escape", DismissName, Some(RENAME_CONTEXT)),
     ]);
@@ -163,6 +171,16 @@ pub enum Pane {
     Board,
     Article,
     Table,
+}
+
+/// One step from `at` through `len` entries, wrapping — a list of none has
+/// nowhere to land.
+fn stepped(at: Option<usize>, len: usize, step: isize) -> Option<usize> {
+    if len == 0 {
+        return None;
+    }
+    let at = at.unwrap_or(0) as isize;
+    Some((at + step).rem_euclid(len as isize) as usize)
 }
 
 /// The root view. It owns no app state — only the chrome's own: how wide the
@@ -185,6 +203,9 @@ pub struct Cydonia {
     pub(crate) name_field: Entity<TextField>,
     meter: Entity<Stats>,
     meter_at: Floating,
+    /// The rail's scroll. A step taken from the keyboard has to bring its
+    /// landing into view; the list does not scroll itself.
+    pub(crate) rail: UniformListScrollHandle,
 }
 
 impl Cydonia {
@@ -232,6 +253,7 @@ impl Cydonia {
             menu: None,
             renaming: None,
             name_field,
+            rail: UniformListScrollHandle::new(),
         };
         this.sync_composer(cx);
         this
@@ -249,6 +271,65 @@ impl Cydonia {
                 workspace.new_session(entry, None, cx);
             }
         });
+    }
+
+    pub(crate) fn next_entry(
+        &mut self,
+        _: &NextEntry,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.cycle_entry(1, window, cx);
+    }
+
+    pub(crate) fn prev_entry(
+        &mut self,
+        _: &PrevEntry,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.cycle_entry(-1, window, cx);
+    }
+
+    /// Step to the next entry of the kind already open, wrapping at the ends.
+    ///
+    /// Inside the project and inside the kind: an article's neighbour is
+    /// another article, because stepping from one into a board would swap the
+    /// pane under the caret for something that reads nothing like it.
+    fn cycle_entry(&mut self, step: isize, window: &mut Window, cx: &mut Context<Self>) {
+        let pane = self.showing(cx);
+        let workspace = self.workspace.read(cx);
+        let Some(project) = workspace.active else {
+            return;
+        };
+        let Some(open) = workspace.projects.get(project) else {
+            return;
+        };
+        // Held across the read, because opening one wants the app mutably.
+        let landing =
+            match pane {
+                Pane::Chat => {
+                    let ids: Vec<u64> = open.ordered().map(|chat| chat.id).collect();
+                    let at = open
+                        .active
+                        .and_then(|id| ids.iter().position(|open| *open == id));
+                    stepped(at, ids.len(), step).map(|ix| Row::Session {
+                        project,
+                        id: ids[ix],
+                    })
+                }
+                Pane::Article => stepped(open.article, open.articles.len(), step)
+                    .map(|ix| Row::Article { project, ix }),
+                Pane::Board => stepped(open.board, open.boards.len(), step)
+                    .map(|ix| Row::Board { project, ix }),
+                Pane::Table => stepped(open.table, open.tables.len(), step)
+                    .map(|ix| Row::Table { project, ix }),
+            };
+        let Some(landing) = landing else {
+            return;
+        };
+        self.open_row(landing, window, cx);
+        self.reveal(landing, cx);
     }
 
     /// Leaving a project is the moment a half-written card has to be filed:
@@ -375,6 +456,8 @@ impl Render for Cydonia {
             .on_action(cx.listener(Self::dismiss_cell))
             .on_action(cx.listener(Self::open_project_action))
             .on_action(cx.listener(Self::open_settings_action))
+            .on_action(cx.listener(Self::next_entry))
+            .on_action(cx.listener(Self::prev_entry))
             .on_action(cx.listener(Self::commit_name))
             .on_action(cx.listener(Self::dismiss_name))
             .on_drag_move(

--- a/src/view/root.rs
+++ b/src/view/root.rs
@@ -109,7 +109,7 @@ pub(crate) fn content_bg(theme: &Theme) -> Hsla {
 /// the window shows no desktop to sit over. The scale's tone is a neutral scrim
 /// and carries no appearance — tinting it is what makes dark glass dark.
 fn frost(theme: &Theme, thickness: Frost) -> Option<Hsla> {
-    theme.glass_window().then(|| Hsla {
+    theme.vibrancy.then(|| Hsla {
         a: thickness.opacity(),
         ..theme.glass()
     })

--- a/src/view/root.rs
+++ b/src/view/root.rs
@@ -21,7 +21,7 @@ use bezel::{
         PathPromptOptions, Render, Window, WindowHandle, actions, div, prelude::*, px,
     },
     motion::{Fade, Painter},
-    theme::{Frost, TextStyle, Theme, Typeset},
+    theme::{Appearance, Frost, SurfaceStyle, TextStyle, Theme, Typeset},
     ui::{
         floating::Floating,
         icons,
@@ -57,6 +57,16 @@ pub(crate) const SIDEBAR_GUTTER: f32 = 8.;
 /// the panel is the column whose text has to win against the desktop.
 const SIDEBAR_FROST: Frost = Frost::Thick;
 const CONTENT_FROST: Frost = Frost::UltraThick;
+
+/// bezel's palette with cydonia's popover surface on it. Registered as the
+/// app's builder so a light/dark switch rebuilds it — `appearance::apply`
+/// drops a palette that was only installed.
+pub fn palette(appearance: Appearance) -> Theme {
+    Theme {
+        popover_surface: SurfaceStyle::Frost(Frost::Thick),
+        ..Theme::for_appearance(appearance)
+    }
+}
 
 /// The header strip's height, measured off `../desktop`: between Cursor's 34
 /// and Notion's 36, and tall enough to hold the 14px traffic lights macOS 26

--- a/src/view/root.rs
+++ b/src/view/root.rs
@@ -22,7 +22,7 @@ use bezel::{
         prelude::*, px,
     },
     motion::{Fade, Painter},
-    theme::{Appearance, Material, SurfaceStyle, TextStyle, Theme, Typeset},
+    theme::{Material, TextStyle, Theme, Typeset},
     ui::{
         floating::Floating,
         icons,
@@ -60,16 +60,6 @@ pub(crate) const SIDEBAR_GUTTER: f32 = 8.;
 /// text, the panel is the column whose text has to win against the desktop.
 const SIDEBAR_MATERIAL: Material = Material::Thick;
 const CONTENT_MATERIAL: Material = Material::UltraThick;
-
-/// bezel's palette with cydonia's popover surface on it. Registered as the
-/// app's builder so a light/dark switch rebuilds it — `appearance::apply`
-/// drops a palette that was only installed.
-pub fn palette(appearance: Appearance) -> Theme {
-    Theme {
-        popover_surface: SurfaceStyle::Material(Material::Thick),
-        ..Theme::for_appearance(appearance)
-    }
-}
 
 /// The header strip's height, measured off `../desktop`: between Cursor's 34
 /// and Notion's 36, and tall enough to hold the 14px traffic lights macOS 26

--- a/src/view/root.rs
+++ b/src/view/root.rs
@@ -389,17 +389,28 @@ impl Cydonia {
     }
 
     /// Which pane is on screen, as against [`Self::pane`], which is the one
-    /// asked for. They part when the article it points at is gone — deleted,
-    /// or in a project that has none open — and the conversation stands in.
-    /// The sidebar reads this, not the request: a row lit for a pane nobody can
-    /// see is the second selection the eye finds.
+    /// asked for. They part when what it points at is gone — deleted, or in a
+    /// project that has none open — and whatever the project does have stands
+    /// in, so a launch lands on the entry it was left on rather than on an
+    /// empty conversation. The sidebar reads this, not the request: a row lit
+    /// for a pane nobody can see is the second selection the eye finds.
     pub(crate) fn showing(&self, cx: &App) -> Pane {
-        match self.pane {
-            Pane::Board if self.workspace.read(cx).active_board().is_none() => Pane::Chat,
-            Pane::Article if self.workspace.read(cx).active_article().is_none() => Pane::Chat,
-            Pane::Table if self.workspace.read(cx).active_table().is_none() => Pane::Chat,
-            pane => pane,
+        let open = |pane| {
+            let workspace = self.workspace.read(cx);
+            match pane {
+                Pane::Chat => workspace.active_session().is_some(),
+                Pane::Board => workspace.active_board().is_some(),
+                Pane::Article => workspace.active_article().is_some(),
+                Pane::Table => workspace.active_table().is_some(),
+            }
+        };
+        if open(self.pane) {
+            return self.pane;
         }
+        [Pane::Chat, Pane::Board, Pane::Article, Pane::Table]
+            .into_iter()
+            .find(|&pane| open(pane))
+            .unwrap_or(Pane::Chat)
     }
 
     /// Nothing is open, so there is nowhere to send a prompt — the only thing

--- a/src/view/root.rs
+++ b/src/view/root.rs
@@ -21,7 +21,7 @@ use bezel::{
         PathPromptOptions, Render, Window, WindowHandle, actions, div, prelude::*, px,
     },
     motion::{Fade, Painter},
-    theme::{Appearance, Frost, SurfaceStyle, TextStyle, Theme, Typeset},
+    theme::{Appearance, Material, SurfaceStyle, TextStyle, Theme, Typeset},
     ui::{
         floating::Floating,
         icons,
@@ -52,18 +52,18 @@ const SIDEBAR_WIDTH_MAX: f32 = 420.;
 /// The sidebar's gutter: a row's outer margin, and the padding inside it.
 pub(crate) const SIDEBAR_GUTTER: f32 = 8.;
 
-/// How deep each column's frost sits. Nothing paints beneath them, so these are
-/// absolute and independent: the sidebar is chrome and holds no long-form text,
-/// the panel is the column whose text has to win against the desktop.
-const SIDEBAR_FROST: Frost = Frost::Thick;
-const CONTENT_FROST: Frost = Frost::UltraThick;
+/// How thick each column's material sits. Nothing paints beneath them, so these
+/// are absolute and independent: the sidebar is chrome and holds no long-form
+/// text, the panel is the column whose text has to win against the desktop.
+const SIDEBAR_MATERIAL: Material = Material::Thick;
+const CONTENT_MATERIAL: Material = Material::UltraThick;
 
 /// bezel's palette with cydonia's popover surface on it. Registered as the
 /// app's builder so a light/dark switch rebuilds it — `appearance::apply`
 /// drops a palette that was only installed.
 pub fn palette(appearance: Appearance) -> Theme {
     Theme {
-        popover_surface: SurfaceStyle::Frost(Frost::Thick),
+        popover_surface: SurfaceStyle::Material(Material::Thick),
         ..Theme::for_appearance(appearance)
     }
 }
@@ -97,21 +97,22 @@ pub(crate) const COMPOSER_BOTTOM: f32 = 20.;
 /// `surface` is the grey the content plane's white sits inside, and falling
 /// back to the panel would leave the two columns one flat sheet.
 pub(crate) fn sidebar_bg(theme: &Theme) -> Hsla {
-    frost(theme, SIDEBAR_FROST).unwrap_or(theme.surface)
+    material(theme, SIDEBAR_MATERIAL).unwrap_or(theme.surface)
 }
 
 /// The content column's fill.
 pub(crate) fn content_bg(theme: &Theme) -> Hsla {
-    frost(theme, CONTENT_FROST).unwrap_or(theme.bg)
+    material(theme, CONTENT_MATERIAL).unwrap_or(theme.bg)
 }
 
-/// A column's own tint at one thickness on the frost scale, or nothing where
-/// the window shows no desktop to sit over. The scale's tone is a neutral scrim
-/// and carries no appearance — tinting it is what makes dark glass dark.
-fn frost(theme: &Theme, thickness: Frost) -> Option<Hsla> {
+/// A column's own tint at one thickness on the material ladder, or nothing
+/// where the window shows no desktop to sit over. The ladder's tone is a
+/// neutral scrim and carries no appearance — tinting it is what makes dark
+/// glass dark.
+fn material(theme: &Theme, thickness: Material) -> Option<Hsla> {
     theme.vibrancy.then(|| Hsla {
         a: thickness.opacity(),
-        ..theme.glass()
+        ..theme.vibrancy_tint()
     })
 }
 

--- a/src/view/settings/agents.rs
+++ b/src/view/settings/agents.rs
@@ -11,7 +11,7 @@ use bezel::{
     theme::{TextStyle, Theme, Typeset},
     ui::{
         icons,
-        widgets::{ButtonStyle, Buttons, Content, Scaffolding, Status},
+        widgets::{ButtonStyle, Buttons, Content, Controls, Scaffolding, Status},
     },
 };
 
@@ -211,7 +211,58 @@ impl SettingsWindow {
 
     /// The agents section: everything the registry publishes, installed first
     /// so what you already have is what you see.
+    /// The gate over every session. First in the section because nothing below
+    /// it can run while it is off.
+    fn gate_row(&self, cx: &Context<Self>) -> impl IntoElement + use<> {
+        let theme = Theme::of(cx).clone();
+        let on = self.workspace.read(cx).settings.agents_enabled;
+        theme
+            .card_row(true)
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .flex()
+                    .flex_col()
+                    .child(theme.row_title("Enable agents"))
+                    .child(
+                        div()
+                            .mt(px(4.))
+                            .text_style(TextStyle::Subheadline)
+                            .text_color(theme.text_muted)
+                            .child(
+                                "Agents run as downloaded packages on this machine. \
+                                 Sessions cannot be opened while this is off.",
+                            ),
+                    ),
+            )
+            .child(
+                div()
+                    .id("enable-agents")
+                    .cursor_pointer()
+                    .child(theme.toggle(on))
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.workspace
+                            .update(cx, |workspace, cx| workspace.set_agents_enabled(!on, cx));
+                        cx.notify();
+                    })),
+            )
+    }
+
     pub(super) fn agents_body(&self, cx: &Context<Self>) -> AnyElement {
+        let theme = Theme::of(cx).clone();
+        div()
+            .flex()
+            .flex_col()
+            .gap(px(16.))
+            .children(self.error.clone().map(|err| theme.error_strip(err)))
+            .child(theme.group_box().child(self.gate_row(cx)))
+            .child(self.catalogue(cx))
+            .into_any_element()
+    }
+
+    /// What the registry offers, once it has answered.
+    fn catalogue(&self, cx: &Context<Self>) -> AnyElement {
         let theme = Theme::of(cx).clone();
         let Some(listings) = self.listings.as_ref() else {
             return theme
@@ -247,11 +298,6 @@ impl SettingsWindow {
         for (nth, ix) in order.into_iter().enumerate() {
             rows.push(self.agent_row(ix, &listings[ix], nth == 0, cx));
         }
-        div()
-            .flex()
-            .flex_col()
-            .children(self.error.clone().map(|err| theme.error_strip(err)))
-            .child(theme.group_box().children(rows))
-            .into_any_element()
+        theme.group_box().children(rows).into_any_element()
     }
 }

--- a/src/view/settings/agents.rs
+++ b/src/view/settings/agents.rs
@@ -6,7 +6,7 @@ use crate::{
     view::settings::SettingsWindow,
 };
 use bezel::{
-    gpui::{AnyElement, Context, div, prelude::*, px, svg},
+    gpui::{AnyElement, Context, SharedString, div, prelude::*, px, svg},
     motion::{Fade, Painter},
     theme::{TextStyle, Theme, Typeset},
     ui::{
@@ -14,6 +14,32 @@ use bezel::{
         widgets::{ButtonStyle, Buttons, Content, Controls, Scaffolding, Status},
     },
 };
+use cacp_agents::Distribution;
+
+/// An address that opens in the browser, shown as its own text.
+fn link(
+    id: (&'static str, usize),
+    label: SharedString,
+    url: String,
+    theme: &Theme,
+) -> impl IntoElement {
+    div()
+        .id(id)
+        .cursor_pointer()
+        .hover(|el| el.text_color(theme.accent))
+        .overflow_hidden()
+        .whitespace_nowrap()
+        .child(label)
+        .on_click(move |_, _, cx| cx.open_url(&url))
+}
+
+/// A URL as an address rather than a link: the scheme is noise in a row.
+fn trimmed(url: &str) -> String {
+    url.trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_end_matches('/')
+        .to_owned()
+}
 
 impl SettingsWindow {
     /// Fetch the catalog and each agent's local state, off the UI thread.
@@ -126,6 +152,26 @@ impl SettingsWindow {
         let painter = Painter::of(cx);
         let busy = self.busy.contains(&listing.agent.id);
         let installed = listing.installed.clone();
+        // What this row would actually download, and where it is published.
+        // The spec carries the pinned version; the link drops it, because the
+        // package's own page resolves whether or not that version still does.
+        let npm = match &listing.agent.distribution {
+            Distribution::Npm { package, .. } => Some((
+                SharedString::from(package.clone()),
+                format!(
+                    "https://www.npmjs.com/package/{}",
+                    cacp_agents::package_name(package)
+                ),
+            )),
+            _ => None,
+        };
+        // Where the project itself lives. A proprietary agent publishes no
+        // repository, which is the only link a binary distribution has.
+        let source = listing
+            .agent
+            .repository
+            .clone()
+            .or_else(|| listing.agent.website.clone());
         theme
             .card_row(first)
             .child(
@@ -164,6 +210,20 @@ impl SettingsWindow {
                                     .clone()
                                     .unwrap_or_else(|| listing.agent.id.clone()),
                             ),
+                    )
+                    .child(
+                        div()
+                            .mt(px(2.))
+                            .flex()
+                            .gap(px(8.))
+                            .overflow_hidden()
+                            .text_style(TextStyle::Caption)
+                            .text_color(theme.text_faint)
+                            .children(npm.map(|(spec, url)| link(("npm", ix), spec, url, &theme)))
+                            .children(source.map(|url| {
+                                let label = SharedString::from(trimmed(&url));
+                                link(("source", ix), label, url, &theme)
+                            })),
                     ),
             )
             .children(
@@ -254,9 +314,9 @@ impl SettingsWindow {
         div()
             .flex()
             .flex_col()
-            .gap(px(16.))
             .children(self.error.clone().map(|err| theme.error_strip(err)))
             .child(theme.group_box().child(self.gate_row(cx)))
+            .child(theme.field_label("Clients").mt(px(24.)))
             .child(self.catalogue(cx))
             .into_any_element()
     }

--- a/src/view/settings/mod.rs
+++ b/src/view/settings/mod.rs
@@ -205,6 +205,7 @@ impl SettingsWindow {
             .border_color(theme.border)
             .flex()
             .flex_col()
+            .gap(px(2.))
             .px(px(8.))
             .pb(px(8.))
             // Clears the traffic lights, which have no strip of their own.

--- a/src/view/settings/mod.rs
+++ b/src/view/settings/mod.rs
@@ -1,7 +1,7 @@
 //! The settings window: a sidebar of sections, and the active section's body
 //! centred under its title.
 //!
-//! A window rather than a sheet, and **opaque** rather than frosted. Settings
+//! A window rather than a sheet, and **opaque** rather than vibrant. Settings
 //! is content, not chrome — a translucent panel would put the app you just
 //! navigated away from directly behind the form you are filling in.
 

--- a/src/view/settings/theme.rs
+++ b/src/view/settings/theme.rs
@@ -136,7 +136,7 @@ impl SettingsWindow {
             .into_any_element()
     }
 
-    /// The app's own reduce-transparency switch, so the frost can go without
+    /// The app's own reduce-transparency switch, so the vibrancy can go without
     /// turning the system setting on for every other app.
     pub(super) fn transparency_row(&self, cx: &mut Context<Self>) -> impl IntoElement + use<> {
         let theme = Theme::of(cx).clone();

--- a/src/view/settings/theme.rs
+++ b/src/view/settings/theme.rs
@@ -30,9 +30,10 @@ const MODES: [AppearanceMode; 3] = [
 ];
 
 impl SettingsWindow {
-    /// The whole page: the mode it paints in, then the colours it mixes and
-    /// the size it reads at. Typography is a group here rather than a section
-    /// of its own — a size is a question about appearance.
+    /// The whole page: the mode it paints in, then the colours it mixes, the
+    /// size it reads at, and how the caret behaves in what it writes.
+    /// Typography is a group here rather than a section of its own — a size is
+    /// a question about appearance.
     pub(super) fn appearance_body(&self, cx: &mut Context<Self>) -> AnyElement {
         let theme = Theme::of(cx).clone();
         div()
@@ -42,6 +43,7 @@ impl SettingsWindow {
             .child(theme.group_box().child(self.theme_row(cx)))
             .child(self.colors_group(cx))
             .child(self.typography_group(cx))
+            .child(self.editor_group(cx))
             .into_any_element()
     }
 
@@ -122,6 +124,18 @@ impl SettingsWindow {
             .into_any_element()
     }
 
+    /// How the caret behaves — the editor's and every field's alike.
+    fn editor_group(&self, cx: &mut Context<Self>) -> AnyElement {
+        let theme = Theme::of(cx).clone();
+        div()
+            .flex()
+            .flex_col()
+            .gap(px(settings::LABEL_GAP))
+            .child(theme.field_label("Editor"))
+            .child(theme.group_box().child(self.cursor_row(cx)))
+            .into_any_element()
+    }
+
     /// The app's own reduce-transparency switch, so the frost can go without
     /// turning the system setting on for every other app.
     pub(super) fn transparency_row(&self, cx: &mut Context<Self>) -> impl IntoElement + use<> {
@@ -153,6 +167,41 @@ impl SettingsWindow {
                         this.workspace.update(cx, |workspace, cx| {
                             workspace.set_reduce_transparency(!on, cx)
                         });
+                        cx.notify();
+                    })),
+            )
+    }
+
+    /// Whether the caret blinks. bezel holds the caret, so the switch sets it
+    /// there rather than keeping a second copy of the answer.
+    pub(super) fn cursor_row(&self, cx: &mut Context<Self>) -> impl IntoElement + use<> {
+        let theme = Theme::of(cx).clone();
+        let on = self.workspace.read(cx).cursor_blink;
+        theme
+            .card_row(true)
+            .child(
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .flex()
+                    .flex_col()
+                    .child(theme.row_title("Blink the cursor"))
+                    .child(
+                        div()
+                            .mt(px(4.))
+                            .text_style(TextStyle::Subheadline)
+                            .text_color(theme.text_muted)
+                            .child("Off holds the text caret lit while it has focus."),
+                    ),
+            )
+            .child(
+                div()
+                    .id("cursor-blink")
+                    .cursor_pointer()
+                    .child(theme.toggle(on))
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.workspace
+                            .update(cx, |workspace, cx| workspace.set_cursor_blink(!on, cx));
                         cx.notify();
                     })),
             )

--- a/src/view/sidebar.rs
+++ b/src/view/sidebar.rs
@@ -96,7 +96,8 @@ pub(crate) fn row(
         .when(!selected, |el| el.hover(|el| el.bg(theme.element_hover)))
 }
 
-/// The plate's own inset around the control it holds.
+/// The inset [`Buttons::control_group`] holds its controls at, mirrored here
+/// because the height below is measured from it and bezel keeps it private.
 const CLUSTER_PAD: f32 = 2.;
 
 /// The floating cluster's height, half of which is the pill's radius: a ghost
@@ -221,7 +222,8 @@ impl Cydonia {
     /// choose.
     pub(crate) fn fold_cluster(&self, window: &Window, cx: &mut Context<Self>) -> AnyElement {
         let theme = Theme::of(cx).clone();
-        div()
+        theme
+            .control_group()
             .absolute()
             .top(px((root::HEADER_HEIGHT - CLUSTER_HEIGHT) / 2.))
             // Full screen takes the lights away, and the room they needed
@@ -232,10 +234,9 @@ impl Cydonia {
                 root::TOOLBAR_INSET
             }))
             .h(px(CLUSTER_HEIGHT))
-            .p(px(CLUSTER_PAD))
+            // A pill, where the group's own corner is cut for a row of square
+            // buttons. Before the glass, which reads the corners off the box.
             .rounded(px(CLUSTER_HEIGHT / 2.))
-            .flex()
-            .flex_row()
             .items_center()
             .child(self.fold_toggle(theme.text, cx))
             // The same glass bezel's own floating bar mounts on. Its

--- a/src/view/sidebar.rs
+++ b/src/view/sidebar.rs
@@ -110,9 +110,9 @@ impl Cydonia {
             .border_color(theme.border)
             .flex()
             .flex_col()
-            // Both controls out at the trailing edge, the fold last: the
-            // lights float in the leading half of the strip, which is what
-            // leaves nothing there to pad them clear of.
+            // The fold out at the trailing edge: the lights float in the
+            // leading half of the strip, which is what leaves nothing there to
+            // pad them clear of.
             .child(
                 div()
                     .flex_none()
@@ -122,23 +122,6 @@ impl Cydonia {
                     .flex_row()
                     .items_center()
                     .justify_end()
-                    .gap(px(4.))
-                    .child(
-                        theme
-                            .ghost("open-project")
-                            .p(px(4.))
-                            .tooltip(|window, cx| {
-                                Tooltip::with_keystroke("New project", "⌘O", window, cx)
-                            })
-                            .child(
-                                icons::icon(icons::PLUS)
-                                    .size(px(14.))
-                                    .text_color(theme.text_faint),
-                            )
-                            .on_click(cx.listener(|this, _, window, cx| {
-                                this.open_project_action(&OpenProject, window, cx);
-                            })),
-                    )
                     .child(self.fold_toggle(theme.text_faint, cx)),
             )
             .child(
@@ -153,27 +136,51 @@ impl Cydonia {
                     .children(sections),
             )
             .child(
-                theme
-                    .ghost("settings")
+                div()
                     .flex_none()
                     .mx(px(8.))
                     .mb(px(8.))
-                    .px(px(8.))
-                    .py(px(6.))
-                    .gap(px(8.))
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .justify_between()
                     .child(
-                        icons::icon(icons::SETTINGS_MINIMALISTIC)
-                            .size(px(13.))
-                            .text_color(theme.text_faint),
+                        theme
+                            .ghost("settings")
+                            .px(px(8.))
+                            .py(px(6.))
+                            .gap(px(8.))
+                            .child(
+                                icons::icon(icons::SETTINGS_MINIMALISTIC)
+                                    .size(px(13.))
+                                    .text_color(theme.text_faint),
+                            )
+                            .child(
+                                div()
+                                    .text_style(TextStyle::Body)
+                                    .text_color(theme.text_muted)
+                                    .child("Settings"),
+                            )
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.open_settings(Section::Appearance, cx)
+                            })),
                     )
                     .child(
-                        div()
-                            .text_style(TextStyle::Body)
-                            .text_color(theme.text_muted)
-                            .child("Settings"),
-                    )
-                    .on_click(
-                        cx.listener(|this, _, _, cx| this.open_settings(Section::Appearance, cx)),
+                        theme
+                            .ghost("open-project")
+                            .px(px(8.))
+                            .py(px(6.))
+                            .tooltip(|window, cx| {
+                                Tooltip::with_keystroke("New project", "⌘O", window, cx)
+                            })
+                            .child(
+                                icons::icon(icons::DOCUMENT_ADD)
+                                    .size(px(13.))
+                                    .text_color(theme.text_faint),
+                            )
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                this.open_project_action(&OpenProject, window, cx);
+                            })),
                     ),
             )
     }

--- a/src/view/sidebar.rs
+++ b/src/view/sidebar.rs
@@ -465,14 +465,17 @@ impl Cydonia {
         if self.menu != Some(Menu::Add(ix)) {
             return None;
         }
-        let rows = vec![
-            menu::row(
+        let mut rows = Vec::new();
+        if self.workspace.read(cx).settings.agents_enabled {
+            rows.push(menu::row(
                 Item::action("New session").with_icon(icons::CHAT_ROUND_LINE),
                 move |this, window, cx| {
                     this.select_project(ix, cx);
                     this.new_session_action(&NewSession, window, cx);
                 },
-            ),
+            ));
+        }
+        rows.extend([
             menu::row(
                 Item::action("New board").with_icon(icons::LIST),
                 move |this, _, cx| this.new_board(ix, cx),
@@ -485,7 +488,7 @@ impl Cydonia {
                 Item::action("New table").with_icon(icons::WIDGET),
                 move |this, _, cx| this.new_table(ix, cx),
             ),
-        ];
+        ]);
         let id = SharedString::from(format!("add-menu-{ix}"));
         Some(popover::anchored_menu_below(
             id.clone(),

--- a/src/view/sidebar.rs
+++ b/src/view/sidebar.rs
@@ -13,7 +13,7 @@ use crate::{
 use bezel::{
     gpui::{
         self, AnyElement, Context, Div, Empty, Focusable as _, FontWeight, Hsla, MouseButton,
-        SharedString, Stateful, Window, div, prelude::*, px, svg, uniform_list,
+        ScrollStrategy, SharedString, Stateful, Window, div, prelude::*, px, svg, uniform_list,
     },
     motion::Painter,
     theme::{TextStyle, Theme, Typeset},
@@ -42,8 +42,8 @@ struct SessionRow {
 /// One line of the sidebar. An address, not content: the label behind it is
 /// read when the row is built, which [`uniform_list`] only does for the rows on
 /// screen.
-#[derive(Clone, Copy)]
-enum Row {
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) enum Row {
     Project(usize),
     Session { project: usize, id: u64 },
     Board { project: usize, ix: usize },
@@ -157,6 +157,7 @@ impl Cydonia {
                         range.map(|ix| this.sidebar_row(rows[ix], cx)).collect()
                     }),
                 )
+                .track_scroll(&self.rail)
                 .flex_1()
                 .min_h_0(),
             )
@@ -345,7 +346,7 @@ impl Cydonia {
     /// Every line the sidebar shows, in order. Addresses only: a project with a
     /// thousand articles costs a thousand `Row`s here and reads a title for
     /// none of them.
-    fn rows(&self, cx: &Context<Self>) -> Vec<Row> {
+    pub(crate) fn rows(&self, cx: &Context<Self>) -> Vec<Row> {
         let workspace = self.workspace.read(cx);
         let mut rows = Vec::new();
         for (p, project) in workspace.projects.iter().enumerate() {
@@ -362,6 +363,28 @@ impl Cydonia {
             rows.extend((0..project.tables.len()).map(|ix| Row::Table { project: p, ix }));
         }
         rows
+    }
+
+    /// Open what a row points at — what a keyboard step does with its landing.
+    /// The pointer never comes through here: each row carries its own
+    /// `on_click`, which needs no [`Row`] to know what it is.
+    pub(crate) fn open_row(&mut self, row: Row, window: &mut Window, cx: &mut Context<Self>) {
+        match row {
+            Row::Project(ix) => self.select_project(ix, cx),
+            Row::Session { id, .. } => self.select_session(id, cx),
+            Row::Board { project, ix } => self.open_board(project, ix, cx),
+            Row::Article { project, ix } => self.open_article(project, ix, window, cx),
+            Row::Table { project, ix } => self.open_table(project, ix, cx),
+        }
+    }
+
+    /// Scroll the rail to a row, if it is not already on screen. `Nearest`
+    /// rather than `Top`: a step to the neighbour below should move the list by
+    /// a row, not throw the one you came from off the top of it.
+    pub(crate) fn reveal(&mut self, row: Row, cx: &Context<Self>) {
+        if let Some(ix) = self.rows(cx).iter().position(|at| *at == row) {
+            self.rail.scroll_to_item(ix, ScrollStrategy::Nearest);
+        }
     }
 
     /// One line, built when the list scrolls it into view. The box around it is

--- a/src/view/sidebar.rs
+++ b/src/view/sidebar.rs
@@ -13,7 +13,7 @@ use crate::{
 use bezel::{
     gpui::{
         self, AnyElement, Context, Div, Empty, Focusable as _, FontWeight, Hsla, MouseButton,
-        SharedString, Stateful, Window, div, prelude::*, px, svg,
+        SharedString, Stateful, Window, div, prelude::*, px, svg, uniform_list,
     },
     motion::Painter,
     theme::{TextStyle, Theme, Typeset},
@@ -26,6 +26,7 @@ use bezel::{
         widgets::{Buttons, Layout},
     },
 };
+use std::ops::Range;
 
 /// What the sidebar needs of a session to draw its row, read out of the model
 /// before the row is built: a turn in flight puts a thinking orb in the mark's
@@ -38,6 +39,18 @@ struct SessionRow {
     archived: bool,
 }
 
+/// One line of the sidebar. An address, not content: the label behind it is
+/// read when the row is built, which [`uniform_list`] only does for the rows on
+/// screen.
+#[derive(Clone, Copy)]
+enum Row {
+    Project(usize),
+    Session { project: usize, id: u64 },
+    Board { project: usize, ix: usize },
+    Article { project: usize, ix: usize },
+    Table { project: usize, ix: usize },
+}
+
 /// What the sidebar's name field is attached to. One field for both, because
 /// only one row can be being named at a time.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -45,6 +58,13 @@ pub(crate) enum Renaming {
     Session(u64),
     Board { project: usize, ix: usize },
 }
+
+/// The wash a row paints, and — with the 1px either side of it that used to be
+/// the column's gap — the pitch the list lays every row out at. One height for
+/// headings and rows alike, because [`uniform_list`] measures a single row and
+/// gives every other one the same.
+const ROW_PILL: f32 = 30.;
+pub(crate) const ROW_HEIGHT: f32 = ROW_PILL + 2.;
 
 /// The box every row under a project heading sits in: indented beneath the
 /// heading, and carrying the wash that says which one is open.
@@ -60,9 +80,14 @@ pub(crate) fn row(
     div()
         .id(id)
         .group(group)
+        .h(px(ROW_PILL))
         .ml(px(root::SIDEBAR_GUTTER))
         .mr(px(root::SIDEBAR_GUTTER))
         .px(px(root::SIDEBAR_GUTTER))
+        .flex()
+        .flex_row()
+        .items_center()
+        .gap(px(8.))
         .rounded(px(Theme::control_radius()))
         .cursor_pointer()
         .when(selected, |el| el.bg(theme.element_active))
@@ -96,8 +121,8 @@ fn row_label(name: String, tint: Hsla) -> AnyElement {
 impl Cydonia {
     pub(crate) fn sidebar(&self, cx: &mut Context<Self>) -> impl IntoElement + use<> {
         let theme = Theme::of(cx).clone();
-        let count = self.workspace.read(cx).projects.len();
-        let sections: Vec<AnyElement> = (0..count).map(|ix| self.project_section(ix, cx)).collect();
+        let rows = self.rows(cx);
+        let count = rows.len();
         div()
             .flex_none()
             .w(px(self.sidebar_width))
@@ -125,15 +150,15 @@ impl Cydonia {
                     .child(self.fold_toggle(theme.text_faint, cx)),
             )
             .child(
-                div()
-                    .id("project-list")
-                    .flex_1()
-                    .min_h_0()
-                    .overflow_y_scroll()
-                    .flex()
-                    .flex_col()
-                    .gap(px(12.))
-                    .children(sections),
+                uniform_list(
+                    "project-list",
+                    count,
+                    cx.processor(move |this, range: Range<usize>, _, cx| {
+                        range.map(|ix| this.sidebar_row(rows[ix], cx)).collect()
+                    }),
+                )
+                .flex_1()
+                .min_h_0(),
             )
             .child(
                 div()
@@ -242,135 +267,163 @@ impl Cydonia {
             .on_click(cx.listener(|this, _, _, cx| this.toggle_sidebar(cx)))
     }
 
-    /// One project in the sidebar: a heading that folds, and everything in the
-    /// project under it.
-    fn project_section(&self, ix: usize, cx: &mut Context<Self>) -> AnyElement {
+    /// One project's heading: it folds, and its `+` opens what can be made in
+    /// the project.
+    fn project_head(&self, ix: usize, cx: &mut Context<Self>) -> AnyElement {
         let theme = Theme::of(cx).clone();
-        let workspace = self.workspace.read(cx);
-        let Some(project) = workspace.projects.get(ix) else {
-            return Empty.into_any_element();
+        let (name, expanded) = match self.workspace.read(cx).projects.get(ix) {
+            Some(project) => (project.name(), project.expanded),
+            None => return Empty.into_any_element(),
         };
-        let expanded = project.expanded;
-        let name = project.name();
-        let sessions: Vec<SessionRow> = project
-            .ordered()
-            .map(|chat| SessionRow {
-                id: chat.id,
-                label: chat.label(),
-                icon: workspace.agent_icon(&chat.entry.name),
-                streaming: chat.streaming,
-                archived: chat.closed,
-            })
-            .collect();
-        let boards: Vec<(usize, String)> = project
-            .boards
-            .iter()
-            .enumerate()
-            .map(|(n, board)| (n, board.label().to_owned()))
-            .collect();
-        let articles: Vec<(usize, String)> = project
-            .articles
-            .iter()
-            .enumerate()
-            .map(|(n, article)| (n, article.label().to_owned()))
-            .collect();
-        let tables: Vec<(usize, String)> = project
-            .tables
-            .iter()
-            .enumerate()
-            .map(|(n, table)| (n, table.name.clone()))
-            .collect();
-
         div()
+            .id(("project", ix))
+            .group("project-head")
+            .mx(px(8.))
+            .px(px(6.))
+            .h(px(ROW_PILL))
+            .rounded(px(Theme::control_radius()))
+            .relative()
             .flex()
-            .flex_col()
-            .gap(px(2.))
+            .flex_row()
+            .items_center()
+            .gap(px(4.))
+            .cursor_pointer()
+            // On the head, not the label: a name's colour is fixed when
+            // its text is laid out, and only this div is stateful enough
+            // to carry the hover that far.
+            .text_color(theme.text_faint)
+            .hover(|el| el.text_color(theme.text))
             .child(
                 div()
-                    .id(("project", ix))
-                    .group("project-head")
-                    .mx(px(8.))
-                    .px(px(6.))
-                    .py(px(4.))
-                    .rounded(px(Theme::control_radius()))
-                    .relative()
-                    .flex()
-                    .flex_row()
-                    .items_center()
-                    .gap(px(4.))
-                    .cursor_pointer()
-                    // On the head, not the label: a name's colour is fixed when
-                    // its text is laid out, and only this div is stateful enough
-                    // to carry the hover that far.
-                    .text_color(theme.text_faint)
-                    .hover(|el| el.text_color(theme.text))
-                    .child(
-                        div()
-                            .flex_1()
-                            .min_w_0()
-                            .truncate()
-                            .text_style(TextStyle::Callout)
-                            .font_weight(FontWeight::MEDIUM)
-                            .child(name),
-                    )
-                    .child(
-                        self.menu_button(
-                            ("project-add", ix),
-                            "project-head",
-                            icons::icon(icons::PLUS)
-                                .size(px(12.))
-                                .text_color(theme.text_faint)
-                                .group_hover("project-head", |el| el.text_color(theme.text)),
-                            Menu::Add(ix),
-                            cx,
-                        )
-                        .children(self.add_menu(ix, cx)),
-                    )
+                    .flex_1()
+                    .min_w_0()
+                    .truncate()
+                    .text_style(TextStyle::Callout)
+                    .font_weight(FontWeight::MEDIUM)
+                    .child(name),
+            )
+            .child(
+                self.menu_button(
+                    ("project-add", ix),
+                    "project-head",
+                    icons::icon(icons::PLUS)
+                        .size(px(12.))
+                        .text_color(theme.text_faint)
+                        .group_hover("project-head", |el| el.text_color(theme.text)),
+                    Menu::Add(ix),
+                    cx,
+                )
+                .children(self.add_menu(ix, cx)),
+            )
+            .child(
+                theme
+                    .ghost(("project-fold", ix))
+                    .flex_none()
+                    .p(px(3.))
+                    .invisible()
+                    .group_hover("project-head", |el| el.visible())
                     .child(
                         theme
-                            .ghost(("project-fold", ix))
-                            .flex_none()
-                            .p(px(3.))
-                            .invisible()
-                            .group_hover("project-head", |el| el.visible())
-                            .child(
-                                theme
-                                    .disclosure(expanded)
-                                    .text_color(theme.text_faint)
-                                    .group_hover("project-head", |el| el.text_color(theme.text)),
-                            )
-                            .on_click(cx.listener(move |this, _, _, cx| {
-                                cx.stop_propagation();
-                                this.toggle_project(ix, cx);
-                            })),
+                            .disclosure(expanded)
+                            .text_color(theme.text_faint)
+                            .group_hover("project-head", |el| el.text_color(theme.text)),
                     )
-                    .children(self.project_menu(ix, cx))
-                    .on_mouse_down(
-                        MouseButton::Right,
-                        cx.listener(move |this, _, _, cx| this.toggle_menu(Menu::Project(ix), cx)),
-                    )
-                    .on_click(cx.listener(move |this, _, _, cx| this.toggle_project(ix, cx))),
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        cx.stop_propagation();
+                        this.toggle_project(ix, cx);
+                    })),
             )
-            .when(expanded, |section| {
-                section
-                    .children(sessions.into_iter().map(|row| self.session_row(row, cx)))
-                    .children(
-                        boards
-                            .into_iter()
-                            .map(|(n, name)| self.board_row(ix, n, name, cx)),
-                    )
-                    .children(
-                        articles.into_iter().map(|(n, title)| {
-                            self.article_row(ix, n, title, cx).into_any_element()
-                        }),
-                    )
-                    .children(
-                        tables
-                            .into_iter()
-                            .map(|(n, name)| self.table_row(ix, n, name, cx).into_any_element()),
-                    )
-            })
+            .children(self.project_menu(ix, cx))
+            .on_mouse_down(
+                MouseButton::Right,
+                cx.listener(move |this, _, _, cx| this.toggle_menu(Menu::Project(ix), cx)),
+            )
+            .on_click(cx.listener(move |this, _, _, cx| this.toggle_project(ix, cx)))
             .into_any_element()
+    }
+
+    /// Every line the sidebar shows, in order. Addresses only: a project with a
+    /// thousand articles costs a thousand `Row`s here and reads a title for
+    /// none of them.
+    fn rows(&self, cx: &Context<Self>) -> Vec<Row> {
+        let workspace = self.workspace.read(cx);
+        let mut rows = Vec::new();
+        for (p, project) in workspace.projects.iter().enumerate() {
+            rows.push(Row::Project(p));
+            if !project.expanded {
+                continue;
+            }
+            rows.extend(project.ordered().map(|chat| Row::Session {
+                project: p,
+                id: chat.id,
+            }));
+            rows.extend((0..project.boards.len()).map(|ix| Row::Board { project: p, ix }));
+            rows.extend((0..project.articles.len()).map(|ix| Row::Article { project: p, ix }));
+            rows.extend((0..project.tables.len()).map(|ix| Row::Table { project: p, ix }));
+        }
+        rows
+    }
+
+    /// One line, built when the list scrolls it into view. The box around it is
+    /// what holds the pitch: the row inside paints the wash, and the pixel
+    /// either side of it is the gap between two.
+    fn sidebar_row(&self, row: Row, cx: &mut Context<Self>) -> AnyElement {
+        let workspace = self.workspace.read(cx);
+        let inner = match row {
+            Row::Project(ix) => self.project_head(ix, cx),
+            Row::Session { project, id } => match self.session_of(project, id, cx) {
+                Some(session) => self.session_row(session, cx),
+                None => Empty.into_any_element(),
+            },
+            Row::Board { project, ix } => {
+                match workspace
+                    .projects
+                    .get(project)
+                    .and_then(|open| open.boards.get(ix).map(|board| board.label().to_owned()))
+                {
+                    Some(name) => self.board_row(project, ix, name, cx),
+                    None => Empty.into_any_element(),
+                }
+            }
+            Row::Article { project, ix } => {
+                match workspace.projects.get(project).and_then(|open| {
+                    open.articles
+                        .get(ix)
+                        .map(|article| article.label().to_owned())
+                }) {
+                    Some(title) => self.article_row(project, ix, title, cx).into_any_element(),
+                    None => Empty.into_any_element(),
+                }
+            }
+            Row::Table { project, ix } => {
+                match workspace
+                    .projects
+                    .get(project)
+                    .and_then(|open| open.tables.get(ix).map(|table| table.name.clone()))
+                {
+                    Some(name) => self.table_row(project, ix, name, cx).into_any_element(),
+                    None => Empty.into_any_element(),
+                }
+            }
+        };
+        div()
+            .h(px(ROW_HEIGHT))
+            .py(px(1.))
+            .child(inner)
+            .into_any_element()
+    }
+
+    /// What the sidebar needs of a session, read when its row comes on screen.
+    fn session_of(&self, project: usize, id: u64, cx: &Context<Self>) -> Option<SessionRow> {
+        let workspace = self.workspace.read(cx);
+        let chat = workspace.projects.get(project)?.session(id)?;
+        Some(SessionRow {
+            id: chat.id,
+            label: chat.label(),
+            icon: workspace.agent_icon(&chat.entry.name),
+            streaming: chat.streaming,
+            archived: chat.closed,
+        })
     }
 
     fn toggle_project(&mut self, ix: usize, cx: &mut Context<Self>) {
@@ -481,11 +534,6 @@ impl Cydonia {
         };
 
         row(("session", id), "session-row", selected, &theme)
-            .py(px(6.))
-            .flex()
-            .flex_row()
-            .items_center()
-            .gap(px(8.))
             .child(
                 div()
                     .flex_none()
@@ -546,11 +594,6 @@ impl Cydonia {
             selected,
             &theme,
         )
-        .py(px(6.))
-        .flex()
-        .flex_row()
-        .items_center()
-        .gap(px(8.))
         .child(
             icons::icon(icons::LIST)
                 .size(px(14.))

--- a/src/view/table.rs
+++ b/src/view/table.rs
@@ -503,11 +503,6 @@ impl Cydonia {
             selected,
             &theme,
         )
-        .py(px(6.))
-        .flex()
-        .flex_row()
-        .items_center()
-        .gap(px(8.))
         .child(
             icons::icon(icons::WIDGET)
                 .size(px(14.))


### PR DESCRIPTION
### bezel from crates.io

Drops the `[patch.crates-io]` block; the four deps move to the published 0.1.5. Popovers go back to liquid glass — `root::palette` existed only to override `popover_surface`, and bezel's own default is already `Glass::Regular`. Sweeps the last of the `frost` prose left by 947818b.

### Agents off until asked

- `Settings::agents_enabled`, off by default and `#[serde(default)]`, so an existing file reads as disabled. Gates `new_session` and `send` — the two places an agent process starts.
- Catalogue filtered to `claude-acp`, `codex-acp`, `gemini`, `antigravity-acp`. Each row shows the npm spec it would install and the project's source, both linked.
- `Agent::pinned` drops a hand-written `@latest` / `@next` / `@^1.2` entry at load. The line stays in the file where it can be fixed.
- Not closed: pinning a package does not pin its dependency tree, and MCP is the larger unpinned surface.

### Opening where you left off

- `state.toml` gains a `last` map, project → `{ kind, id }`, keyed by the entry's own path rather than an index, which drifts as siblings come and go. Old state files still parse.
- `showing()` no longer treats Chat as the universal fallback — that is why a project full of articles opened on "No session".
- The empty state names its project and lists the kinds as rows that create on click. Composer hidden there.
- Entries ordered by last edit, newest first. Articles and boards were sorting by creation stamp.

### Review note

`cacp` is a path dependency and this needs two commits from the sibling checkout — `contained`, and `website` on the registry agent, the only link Antigravity has.

Build, clippy and fmt are clean.